### PR TITLE
Add a big note with example about deprecated share() method

### DIFF
--- a/challenges.yml
+++ b/challenges.yml
@@ -259,9 +259,24 @@ injectioninterfaces_interfacetypehintcoding:
 # Container
 container_moveservicecreationtocontainercoding:
     question: |
-        Ok, it's time to get organized! You've already installed the
-        `pimple/pimple` library *and* created your `$container` variable.
+        Ok, it's time to get organized! You've already installed the `pimple/pimple`
+        library which has version 3.0 *and* created your `$container` variable.
         Now, add two services to it.
+        
+        ***TIP
+        Keep in mind, that since Pimple 2.0 you don't have to wrap your anonymous
+        function with the `share()` method anymore:
+        
+        ```php
+        $container = new Container();
+        $container['mailer'] = function() {
+            return new Mailer();
+        };
+        ```
+
+        The `mailer` service will be created only once on the first call no matter
+        how many times you'll call it.
+        ***
     question_steps:
         - Add the `email_loader` service for the `EmailAddressLoader` object.
         - Add the `happy_sender` service for the `HappyMessageSender` object.

--- a/challenges.yml
+++ b/challenges.yml
@@ -260,12 +260,12 @@ injectioninterfaces_interfacetypehintcoding:
 container_moveservicecreationtocontainercoding:
     question: |
         Ok, it's time to get organized! You've already installed the `pimple/pimple`
-        library which has version 3.0 *and* created your `$container` variable.
-        Now, add two services to it.
+        library at version 3.0 *and* created your `$container` variable. Now, add two
+        services to it.
         
         ***TIP
-        Keep in mind, that since Pimple 2.0 you don't have to wrap your anonymous
-        function with the `share()` method anymore:
+        In Pimple 3.0, you don't need to wrap your anonymous function with the `share()`
+        method anymore. Now, it's much simpler!
         
         ```php
         $container = new Container();
@@ -274,8 +274,8 @@ container_moveservicecreationtocontainercoding:
         };
         ```
 
-        The `mailer` service will be created only once on the first call no matter
-        how many times you'll call it.
+        Like in earlier Pimple versions, the `mailer` service will still be created
+        only once.
         ***
     question_steps:
         - Add the `email_loader` service for the `EmailAddressLoader` object.


### PR DESCRIPTION
In complement to the note in https://github.com/knpuniversity/dependency-injection/pull/10